### PR TITLE
Fixed units issue on Entropy

### DIFF
--- a/SharpFluids/CoolPropFiles/AbstractState.cs
+++ b/SharpFluids/CoolPropFiles/AbstractState.cs
@@ -315,12 +315,12 @@ public class AbstractState : IDisposable
         else        
             return SpecificEnergy.FromJoulesPerKilogram(CoolPropPINVOKE.AbstractState_hmass(swigCPtr));        
     }
-    public Entropy smass()
+    public SpecificEntropy smass()
     {
         if (Environment.Is64BitProcess)        
-            return Entropy.FromJoulesPerKelvin(CoolPropPINVOKE64.AbstractState_smass(swigCPtr));
+            return SpecificEntropy.FromJoulesPerKilogramKelvin(CoolPropPINVOKE64.AbstractState_smass(swigCPtr));
         else        
-            return Entropy.FromJoulesPerKelvin(CoolPropPINVOKE.AbstractState_smass(swigCPtr));        
+            return SpecificEntropy.FromJoulesPerKilogramKelvin(CoolPropPINVOKE.AbstractState_smass(swigCPtr));        
     }
     public SpecificEnergy umass()
     {

--- a/SharpFluids/SharpFluids files/Fluid.cs
+++ b/SharpFluids/SharpFluids files/Fluid.cs
@@ -219,7 +219,7 @@ namespace SharpFluids
             Enthalpy = SpecificEnergy.Zero;
             Temperature = Temperature.Zero;
             Pressure = Pressure.Zero;
-            Entropy = Entropy.Zero;
+            Entropy = SpecificEntropy.Zero;
             Quality = 0;
             Density = Density.Zero;
             Cp = SpecificEntropy.Zero;
@@ -324,11 +324,11 @@ namespace SharpFluids
             //After the mixing an Update should be run
 
 
-            if (this.Enthalpy == SpecificEnergy.Zero || this.Pressure == Pressure.Zero || this.Entropy == Entropy.Zero || this.Temperature == Temperature.Zero || this.MassFlow == MassFlow.Zero)
+            if (this.Enthalpy == SpecificEnergy.Zero || this.Pressure == Pressure.Zero || this.Entropy == SpecificEntropy.Zero || this.Temperature == Temperature.Zero || this.MassFlow == MassFlow.Zero)
             {
                 this.Copy(other);
             }
-            else if (other.Enthalpy == SpecificEnergy.Zero || other.Pressure == Pressure.Zero || other.Entropy == Entropy.Zero || other.Temperature == Temperature.Zero || other.MassFlow == MassFlow.Zero)
+            else if (other.Enthalpy == SpecificEnergy.Zero || other.Pressure == Pressure.Zero || other.Entropy == SpecificEntropy.Zero || other.Temperature == Temperature.Zero || other.MassFlow == MassFlow.Zero)
             {
                 //Do nothing
                 Log.Debug($"SharpFluid -> AddTo -> {other.Enthalpy} or {other.Pressure} or {other.Entropy} or {other.Temperature} or {other.MassFlow} is zero and nothing is done!");
@@ -615,7 +615,7 @@ namespace SharpFluids
             Enthalpy = Enthalpy.ToUnit(SpecificEnergyUnit.KilojoulePerKilogram);
             Temperature = Temperature.ToUnit(TemperatureUnit.DegreeCelsius);
             Pressure = Pressure.ToUnit(PressureUnit.Bar);
-            Entropy = Entropy.ToUnit(EntropyUnit.KilojoulePerKelvin);
+            Entropy = Entropy.ToUnit(SpecificEntropyUnit.KilojoulePerKilogramKelvin);
             Density = Density.ToUnit(DensityUnit.KilogramPerCubicMeter);
             Cp = Cp.ToUnit(SpecificEntropyUnit.KilojoulePerKilogramKelvin);
             Cv = Cv.ToUnit(SpecificEntropyUnit.KilojoulePerKilogramKelvin);

--- a/SharpFluids/SharpFluids files/FluidProperties .cs
+++ b/SharpFluids/SharpFluids files/FluidProperties .cs
@@ -56,7 +56,7 @@ namespace SharpFluids
         /// </summary>
         [JsonProperty]
         //[JsonConverter(typeof(UnitsNetIQuantityJsonConverter))]
-        public Entropy Entropy { get; private set; }
+        public SpecificEntropy Entropy { get; private set; }
 
 
         /// <summary>

--- a/SharpFluids/SharpFluids files/FluidUpdates.cs
+++ b/SharpFluids/SharpFluids files/FluidUpdates.cs
@@ -21,7 +21,7 @@ namespace SharpFluids
         /// </summary> 
         /// <param name = "density" > The <see cref="UnitsNet.Density"/> used in the update</param>
         /// <param name = "entropy" > The <see cref="UnitsNet.Entropy"/> used in the update</param>
-        public void UpdateDS(Density density, Entropy entropy)
+        public void UpdateDS(Density density, SpecificEntropy entropy)
         {
             CheckBeforeUpdate();
 
@@ -31,17 +31,17 @@ namespace SharpFluids
             }
 
 
-            if (density <= Density.Zero || entropy <= Entropy.Zero)
+            if (density <= Density.Zero || entropy <= SpecificEntropy.Zero)
             {
                 FailState = true;
-                Log.Debug($"SharpFluid -> UpdateDS -> {density} cant be below {Density.Zero} and {entropy} cant be below {Entropy.Zero}");
+                Log.Debug($"SharpFluid -> UpdateDS -> {density} cant be below {Density.Zero} and {entropy} cant be below {SpecificEntropy.Zero}");
                 return;
             }
 
 
             try
             {
-                REF.update(input_pairs.DmassSmass_INPUTS, density.KilogramsPerCubicMeter, entropy.JoulesPerKelvin);
+                REF.update(input_pairs.DmassSmass_INPUTS, density.KilogramsPerCubicMeter, entropy.JoulesPerKilogramKelvin);
                 UpdateValues();
             }
             catch (System.ApplicationException e)

--- a/UnitsTests/AmmoniaTests.cs
+++ b/UnitsTests/AmmoniaTests.cs
@@ -44,7 +44,7 @@ namespace UnitsTests
             Assert.AreEqual(1.7222578809324292, R717.Prandtl, 0.0001);
             Assert.AreEqual(10, R717.Pressure.Bars, 0.0001);
             Assert.AreEqual(15.362783819911829, R717.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(3846.6363350450893, R717.Entropy.JoulesPerKelvin, 0.0001);
+            Assert.AreEqual(3846.6363350450893, R717.Entropy.JoulesPerKilogramKelvin, 0.0001);
             Assert.AreEqual(0.020506397334553166, R717.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(24.912702090002085, R717.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(24.912702089993616, R717.Tsat.DegreesCelsius, 0.0001);
@@ -94,7 +94,7 @@ namespace UnitsTests
             Assert.AreEqual(0, R717.Prandtl);
             Assert.AreEqual(0, R717.Pressure.Bars);
             Assert.AreEqual(0, R717.Density.KilogramsPerCubicMeter);
-            Assert.AreEqual(0, R717.Entropy.JoulesPerKelvin);
+            Assert.AreEqual(0, R717.Entropy.JoulesPerKilogramKelvin);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter);
             Assert.AreEqual(0, R717.Temperature.Kelvins);
             Assert.AreEqual(0, R717.Tsat.Kelvins);
@@ -144,7 +144,7 @@ namespace UnitsTests
             Assert.AreEqual(0, R717.Prandtl);
             Assert.AreEqual(0, R717.Pressure.Bars);
             Assert.AreEqual(0, R717.Density.KilogramsPerCubicMeter);
-            Assert.AreEqual(0, R717.Entropy.JoulesPerKelvin);
+            Assert.AreEqual(0, R717.Entropy.JoulesPerKilogramKelvin);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter);
             Assert.AreEqual(0, R717.Temperature.Kelvins);
             Assert.AreEqual(0, R717.Tsat.Kelvins);
@@ -196,7 +196,7 @@ namespace UnitsTests
             Assert.AreEqual(1.7222578809324292, R717.Prandtl, 0.0001);
             Assert.AreEqual(10, R717.Pressure.Bars, 0.0001);
             Assert.AreEqual(15.362783819911829, R717.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(0.91936814891141638, R717.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(0.91936814891141638, R717.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0.020506397334553166, R717.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(24.912702090002085, R717.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(24.912702089993616, R717.Tsat.DegreesCelsius, 0.0001);
@@ -247,7 +247,7 @@ namespace UnitsTests
             Assert.AreEqual(0, R717.Prandtl);
             Assert.AreEqual(0, R717.Pressure.Bars);
             Assert.AreEqual(0, R717.Density.KilogramsPerCubicMeter);
-            Assert.AreEqual(0, R717.Entropy.JoulesPerKelvin);
+            Assert.AreEqual(0, R717.Entropy.JoulesPerKilogramKelvin);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter);
             Assert.AreEqual(0, R717.Temperature.Kelvins);
             Assert.AreEqual(0, R717.Tsat.Kelvins);
@@ -298,7 +298,7 @@ namespace UnitsTests
             Assert.AreEqual(0, R717.Prandtl);
             Assert.AreEqual(0, R717.Pressure.Bars);
             Assert.AreEqual(0, R717.Density.KilogramsPerCubicMeter);
-            Assert.AreEqual(0, R717.Entropy.JoulesPerKelvin);
+            Assert.AreEqual(0, R717.Entropy.JoulesPerKilogramKelvin);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter);
             Assert.AreEqual(0, R717.Temperature.Kelvins);
             Assert.AreEqual(0, R717.Tsat.Kelvins);
@@ -323,7 +323,7 @@ namespace UnitsTests
             //Arrange
             Fluid R717 = new Fluid(FluidList.Ammonia);
             Density setDensity = Density.FromKilogramsPerCubicMeter(15.362783819911829);
-            Entropy setEntropy = Entropy.FromJoulesPerKelvin(3846.6363350450893);
+            SpecificEntropy setEntropy = SpecificEntropy.FromJoulesPerKilogramKelvin(3846.6363350450893);
             MassFlow setMassFlow = MassFlow.FromKilogramsPerSecond(2);
 
 
@@ -349,7 +349,7 @@ namespace UnitsTests
             Assert.AreEqual(1.7222578809324292, R717.Prandtl, 0.0001);
             Assert.AreEqual(10, R717.Pressure.Bars, 0.0001);
             Assert.AreEqual(15.362783819911829, R717.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(0.91936814891141638, R717.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(0.91936814891141638, R717.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0.020506397334553166, R717.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(24.912702090002085, R717.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(24.912702089993616, R717.Tsat.DegreesCelsius, 0.0001);
@@ -371,7 +371,7 @@ namespace UnitsTests
             //Arrange
             Fluid R717 = new Fluid(FluidList.Ammonia);
             Density setDensity = Density.FromKilogramsPerCubicMeter(-15.362783819911829);
-            Entropy setEntropy = Entropy.FromJoulesPerKelvin(-3846.6363350450893);
+            SpecificEntropy setEntropy = SpecificEntropy.FromJoulesPerKilogramKelvin(-3846.6363350450893);
             MassFlow setMassFlow = MassFlow.FromKilogramsPerSecond(2);
 
 
@@ -398,7 +398,7 @@ namespace UnitsTests
             Assert.AreEqual(0, R717.Prandtl);
             Assert.AreEqual(0, R717.Pressure.Bars);
             Assert.AreEqual(0, R717.Density.KilogramsPerCubicMeter);
-            Assert.AreEqual(0, R717.Entropy.JoulesPerKelvin);
+            Assert.AreEqual(0, R717.Entropy.JoulesPerKilogramKelvin);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter);
             Assert.AreEqual(0, R717.Temperature.Kelvins);
             Assert.AreEqual(0, R717.Tsat.Kelvins);
@@ -420,7 +420,7 @@ namespace UnitsTests
             //Arrange
             Fluid R717 = new Fluid(FluidList.Ammonia);
             Density setDensity = Density.FromKilogramsPerCubicMeter(1000000);
-            Entropy setEntropy = Entropy.FromJoulesPerKelvin(1000000000);
+            SpecificEntropy setEntropy = SpecificEntropy.FromJoulesPerKilogramKelvin(1000000000);
             MassFlow setMassFlow = MassFlow.FromKilogramsPerSecond(2);
 
 
@@ -447,7 +447,7 @@ namespace UnitsTests
             Assert.AreEqual(0, R717.Prandtl);
             Assert.AreEqual(0, R717.Pressure.Bars);
             Assert.AreEqual(0, R717.Density.KilogramsPerCubicMeter);
-            Assert.AreEqual(0, R717.Entropy.JoulesPerKelvin);
+            Assert.AreEqual(0, R717.Entropy.JoulesPerKilogramKelvin);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter);
             Assert.AreEqual(0, R717.Temperature.Kelvins);
             Assert.AreEqual(0, R717.Tsat.Kelvins);
@@ -496,7 +496,7 @@ namespace UnitsTests
             Assert.AreEqual(1.7222578809324292, R717.Prandtl, 0.0001);
             Assert.AreEqual(10, R717.Pressure.Bars, 0.0001);
             Assert.AreEqual(15.362783819911829, R717.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(0.91936814891141638, R717.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(0.91936814891141638, R717.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0.020506397334553166, R717.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(24.912702090002085, R717.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(24.912702089993616, R717.Tsat.DegreesCelsius, 0.0001);
@@ -545,7 +545,7 @@ namespace UnitsTests
             Assert.AreEqual(0, R717.Prandtl);
             Assert.AreEqual(0, R717.Pressure.Bars);
             Assert.AreEqual(0, R717.Density.KilogramsPerCubicMeter);
-            Assert.AreEqual(0, R717.Entropy.JoulesPerKelvin);
+            Assert.AreEqual(0, R717.Entropy.JoulesPerKilogramKelvin);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter);
             Assert.AreEqual(0, R717.Temperature.Kelvins);
             Assert.AreEqual(0, R717.Tsat.Kelvins);
@@ -613,7 +613,7 @@ namespace UnitsTests
             Assert.AreEqual(1.7222578809324292, R717.Prandtl, 0.0001);
             Assert.AreEqual(10, R717.Pressure.Bars, 0.0001);
             Assert.AreEqual(15.362783819911829, R717.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(0.91936814891141638, R717.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(0.91936814891141638, R717.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0.020506397334553166, R717.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(24.912702090002085, R717.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(24.912702089993616, R717.Tsat.DegreesCelsius, 0.0001);
@@ -662,7 +662,7 @@ namespace UnitsTests
             Assert.AreEqual(0, R717.Prandtl);
             Assert.AreEqual(0, R717.Pressure.Bars);
             Assert.AreEqual(0, R717.Density.KilogramsPerCubicMeter);
-            Assert.AreEqual(0, R717.Entropy.JoulesPerKelvin);
+            Assert.AreEqual(0, R717.Entropy.JoulesPerKilogramKelvin);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter);
             Assert.AreEqual(0, R717.Temperature.Kelvins);
             Assert.AreEqual(0, R717.Tsat.Kelvins);
@@ -711,7 +711,7 @@ namespace UnitsTests
             Assert.AreEqual(0, R717.Prandtl);
             Assert.AreEqual(0, R717.Pressure.Bars);
             Assert.AreEqual(0, R717.Density.KilogramsPerCubicMeter);
-            Assert.AreEqual(0, R717.Entropy.JoulesPerKelvin);
+            Assert.AreEqual(0, R717.Entropy.JoulesPerKilogramKelvin);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter);
             Assert.AreEqual(0, R717.Temperature.Kelvins);
             Assert.AreEqual(0, R717.Tsat.Kelvins);
@@ -761,7 +761,7 @@ namespace UnitsTests
             Assert.AreEqual(1.7222578809324292, R717.Prandtl, 0.0001);
             Assert.AreEqual(10, R717.Pressure.Bars, 0.0001);
             Assert.AreEqual(15.362783819911829, R717.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(0.91936814891141638, R717.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(0.91936814891141638, R717.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0.020506397334553166, R717.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(24.912702090002085, R717.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(24.912702089993616, R717.Tsat.DegreesCelsius, 0.0001);
@@ -811,7 +811,7 @@ namespace UnitsTests
             Assert.AreEqual(0, R717.Prandtl);
             Assert.AreEqual(0, R717.Pressure.Bars);
             Assert.AreEqual(0, R717.Density.KilogramsPerCubicMeter);
-            Assert.AreEqual(0, R717.Entropy.JoulesPerKelvin);
+            Assert.AreEqual(0, R717.Entropy.JoulesPerKilogramKelvin);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter);
             Assert.AreEqual(0, R717.Temperature.Kelvins);
             Assert.AreEqual(0, R717.Tsat.Kelvins);
@@ -861,7 +861,7 @@ namespace UnitsTests
             Assert.AreEqual(0, R717.Prandtl);
             Assert.AreEqual(0, R717.Pressure.Bars);
             Assert.AreEqual(0, R717.Density.KilogramsPerCubicMeter);
-            Assert.AreEqual(0, R717.Entropy.JoulesPerKelvin);
+            Assert.AreEqual(0, R717.Entropy.JoulesPerKilogramKelvin);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter);
             Assert.AreEqual(0, R717.Temperature.Kelvins);
             Assert.AreEqual(0, R717.Tsat.Kelvins);
@@ -911,7 +911,7 @@ namespace UnitsTests
             Assert.AreEqual(1.7222578809324292, R717.Prandtl, 0.0001);
             Assert.AreEqual(10, R717.Pressure.Bars, 0.0001);
             Assert.AreEqual(15.362783819911829, R717.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(0.91936814891141638, R717.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(0.91936814891141638, R717.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0.020506397334553166, R717.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(24.912702090002085, R717.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(24.912702089993616, R717.Tsat.DegreesCelsius, 0.0001);
@@ -961,7 +961,7 @@ namespace UnitsTests
             Assert.AreEqual(0, R717.Prandtl);
             Assert.AreEqual(0, R717.Pressure.Bars);
             Assert.AreEqual(0, R717.Density.KilogramsPerCubicMeter);
-            Assert.AreEqual(0, R717.Entropy.JoulesPerKelvin);
+            Assert.AreEqual(0, R717.Entropy.JoulesPerKilogramKelvin);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter);
             Assert.AreEqual(0, R717.Temperature.Kelvins);
             Assert.AreEqual(0, R717.Tsat.Kelvins);
@@ -1011,7 +1011,7 @@ namespace UnitsTests
             Assert.AreEqual(0, R717.Prandtl);
             Assert.AreEqual(0, R717.Pressure.Bars);
             Assert.AreEqual(0, R717.Density.KilogramsPerCubicMeter);
-            Assert.AreEqual(0, R717.Entropy.JoulesPerKelvin);
+            Assert.AreEqual(0, R717.Entropy.JoulesPerKilogramKelvin);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter);
             Assert.AreEqual(0, R717.Temperature.Kelvins);
             Assert.AreEqual(0, R717.Tsat.Kelvins);
@@ -1061,7 +1061,7 @@ namespace UnitsTests
             Assert.AreEqual(0.92250631570868957, R717.Prandtl, 0.0001);
             Assert.AreEqual(10, R717.Pressure.Bars, 0.0001);
             Assert.AreEqual(5.7513489580705048, R717.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(1.5308777308424815, R717.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(1.5308777308424815, R717.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(100, R717.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(24.912702090001176, R717.Tsat.DegreesCelsius, 0.0001);
@@ -1110,7 +1110,7 @@ namespace UnitsTests
             Assert.AreEqual(0, R717.Prandtl);
             Assert.AreEqual(0, R717.Pressure.Bars);
             Assert.AreEqual(0, R717.Density.KilogramsPerCubicMeter);
-            Assert.AreEqual(0, R717.Entropy.JoulesPerKelvin);
+            Assert.AreEqual(0, R717.Entropy.JoulesPerKilogramKelvin);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter);
             Assert.AreEqual(0, R717.Temperature.Kelvins);
             Assert.AreEqual(0, R717.Tsat.Kelvins);
@@ -1197,7 +1197,7 @@ namespace UnitsTests
             Assert.AreEqual(1.7222578809324292, R717.Prandtl, 0.0001);
             Assert.AreEqual(10, R717.Pressure.Bars, 0.0001);
             Assert.AreEqual(15.362783819911829, R717.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(0.91936814891141638, R717.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(0.91936814891141638, R717.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0.020506397334553166, R717.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(24.912702090002085, R717.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(24.912702089993616, R717.Tsat.DegreesCelsius, 0.0001);
@@ -1247,7 +1247,7 @@ namespace UnitsTests
             Assert.AreEqual(0, R717.Prandtl);
             Assert.AreEqual(0, R717.Pressure.Bars);
             Assert.AreEqual(0, R717.Density.KilogramsPerCubicMeter);
-            Assert.AreEqual(0, R717.Entropy.JoulesPerKelvin);
+            Assert.AreEqual(0, R717.Entropy.JoulesPerKilogramKelvin);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter);
             Assert.AreEqual(0, R717.Temperature.Kelvins);
             Assert.AreEqual(0, R717.Tsat.Kelvins);
@@ -1296,7 +1296,7 @@ namespace UnitsTests
             Assert.AreEqual(0, R717.Prandtl);
             Assert.AreEqual(0, R717.Pressure.Bars);
             Assert.AreEqual(0, R717.Density.KilogramsPerCubicMeter);
-            Assert.AreEqual(0, R717.Entropy.JoulesPerKelvin);
+            Assert.AreEqual(0, R717.Entropy.JoulesPerKilogramKelvin);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter);
             Assert.AreEqual(0, R717.Temperature.Kelvins);
             Assert.AreEqual(0, R717.Tsat.Kelvins);
@@ -1348,7 +1348,7 @@ namespace UnitsTests
             Assert.AreEqual(0, R717.Prandtl, 0.0001);
             Assert.AreEqual(R717.CriticalPressure.Bars, R717.Pressure.Bars, 0.0001);
             Assert.AreEqual(225.00343506206013, R717.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(0.96180688370538459, R717.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(0.96180688370538459, R717.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(R717.CriticalTemperature.DegreesCelsius, R717.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(R717.CriticalTemperature.DegreesCelsius, R717.Tsat.DegreesCelsius, 0.0001);
@@ -1372,7 +1372,7 @@ namespace UnitsTests
             Assert.AreEqual(R717X0.Prandtl, R717.Prandtl, 0.0001);
             Assert.AreEqual(R717X0.Pressure.Bars, R717.Pressure.Bars, 0.0001);
             Assert.AreEqual(R717X0.Density.KilogramsPerCubicMeter, R717.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(R717X0.Entropy.KilocaloriesPerKelvin, R717.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(R717X0.Entropy.CaloriesPerGramKelvin, R717.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(R717X0.SurfaceTension.NewtonsPerMeter, R717.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(R717X0.Temperature.DegreesCelsius, R717.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(R717X0.Tsat.DegreesCelsius, R717.Tsat.DegreesCelsius, 0.0001);
@@ -1424,7 +1424,7 @@ namespace UnitsTests
             Assert.AreEqual(1.7222578809324292, R717.Prandtl, 0.0001);
             Assert.AreEqual(10, R717.Pressure.Bars, 0.0001);
             Assert.AreEqual(15.362783819911829, R717.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(0.91936814891141638, R717.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(0.91936814891141638, R717.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0.020506397334553166, R717.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(24.912702090002085, R717.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(24.912702089993616, R717.Tsat.DegreesCelsius, 0.0001);
@@ -1473,7 +1473,7 @@ namespace UnitsTests
             Assert.AreEqual(0, R717.Prandtl);
             Assert.AreEqual(0, R717.Pressure.Bars);
             Assert.AreEqual(0, R717.Density.KilogramsPerCubicMeter);
-            Assert.AreEqual(0, R717.Entropy.JoulesPerKelvin);
+            Assert.AreEqual(0, R717.Entropy.JoulesPerKilogramKelvin);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter);
             Assert.AreEqual(0, R717.Temperature.Kelvins);
             Assert.AreEqual(0, R717.Tsat.Kelvins);
@@ -1524,7 +1524,7 @@ namespace UnitsTests
             Assert.AreEqual(0, R717.Prandtl);
             Assert.AreEqual(0, R717.Pressure.Bars);
             Assert.AreEqual(0, R717.Density.KilogramsPerCubicMeter);
-            Assert.AreEqual(0, R717.Entropy.JoulesPerKelvin);
+            Assert.AreEqual(0, R717.Entropy.JoulesPerKilogramKelvin);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter);
             Assert.AreEqual(0, R717.Temperature.Kelvins);
             Assert.AreEqual(0, R717.Tsat.Kelvins);

--- a/UnitsTests/Co2Tests.cs
+++ b/UnitsTests/Co2Tests.cs
@@ -39,7 +39,7 @@ namespace UnitsTests
             Assert.AreEqual(8000, Co2.LimitPressureMax.Bars, 0.0001);
             Assert.AreEqual(5.1796434344772573, Co2.LimitPressureMin.Bars, 0.0001);
             Assert.AreEqual(66.78620802621117, Co2.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(0.45619347847526537, Co2.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(0.45619347847526537, Co2.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0, Co2.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(-12.01316976352382, Co2.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(-12.013169763523649, Co2.Tsat.DegreesCelsius, 0.0001);
@@ -88,7 +88,7 @@ namespace UnitsTests
             Assert.AreEqual(8000, Co2.LimitPressureMax.Bars, 0.0001);
             Assert.AreEqual(5.1796434344772573, Co2.LimitPressureMin.Bars, 0.0001);
             Assert.AreEqual(940.51699029972065, Co2.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(0.23630359663511932, Co2.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(0.23630359663511932, Co2.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0, Co2.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(0, Co2.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(14.283923802417348, Co2.Tsat.DegreesCelsius, 0.0001);
@@ -135,7 +135,7 @@ namespace UnitsTests
             Assert.AreEqual(8000, Co2.LimitPressureMax.Bars, 0.0001);
             Assert.AreEqual(5.1796434344772573, Co2.LimitPressureMin.Bars, 0.0001);
             Assert.AreEqual(113.05213925800003, Co2.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(0.4588969385489618, Co2.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(0.4588969385489618, Co2.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0, Co2.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(40, Co2.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(14.283923802417348, Co2.Tsat.DegreesCelsius, 0.0001);
@@ -186,7 +186,7 @@ namespace UnitsTests
             Assert.AreEqual(2.8243769924416289, Co2.Prandtl, 0.0001);
             Assert.AreEqual(90, Co2.Pressure.Bars, 0.0001);
             Assert.AreEqual(744.30948867565462, Co2.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(0.29681456863586464, Co2.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(0.29681456863586464, Co2.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0, Co2.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(30, Co2.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(30.978200000000015, Co2.Tsat.DegreesCelsius, 0.0001);
@@ -234,7 +234,7 @@ namespace UnitsTests
             Assert.AreEqual(2994.270142680401, Co2.Prandtl, 0.01);
             Assert.AreEqual(73.773000000060662, Co2.Pressure.Bars, 0.0001);
             Assert.AreEqual(480.99114269329687, Co2.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(0.34020247992073177, Co2.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(0.34020247992073177, Co2.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0, Co2.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(30.978200000000015, Co2.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(30.978200000012691, Co2.Tsat.DegreesCelsius, 0.0001);
@@ -283,7 +283,7 @@ namespace UnitsTests
             Assert.AreEqual(7.2362227645827124, Co2.Prandtl, 0.0001);
             Assert.AreEqual(25, Co2.Pressure.Bars, 0.0001);
             Assert.AreEqual(125.15644631203638, Co2.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(0.33552673235991382, Co2.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(0.33552673235991382, Co2.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0.006762279814496573, Co2.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(-12.01316976352382, Co2.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(-12.01316976352706, Co2.Tsat.DegreesCelsius, 0.0001);

--- a/UnitsTests/FunctionalityTests.cs
+++ b/UnitsTests/FunctionalityTests.cs
@@ -53,7 +53,7 @@ namespace UnitsTests
             Assert.AreEqual(1.7251500393076753, R717.Prandtl, 0.0001);
             Assert.AreEqual(9.9654295346437216, R717.Pressure.Bars, 0.0001);
             Assert.AreEqual(15.36622602626586, R717.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(0.9176026758197906, R717.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(0.9176026758197906, R717.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0.020532110006759582, R717.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(24.800454983004158, R717.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(24.800454983344366, R717.Tsat.DegreesCelsius, 0.0001);
@@ -84,7 +84,7 @@ namespace UnitsTests
             Assert.AreEqual(R717JSON.Prandtl, R717.Prandtl);
             Assert.AreEqual(R717JSON.Pressure.Bars, R717.Pressure.Bars);
             Assert.AreEqual(R717JSON.Density.KilogramsPerCubicMeter, R717.Density.KilogramsPerCubicMeter);
-            Assert.AreEqual(R717JSON.Entropy.KilocaloriesPerKelvin, R717.Entropy.KilocaloriesPerKelvin);
+            Assert.AreEqual(R717JSON.Entropy.KilocaloriesPerGramKelvin, R717.Entropy.KilocaloriesPerGramKelvin);
             Assert.AreEqual(R717JSON.SurfaceTension.NewtonsPerMeter, R717.SurfaceTension.NewtonsPerMeter);
             Assert.AreEqual(R717JSON.Temperature.DegreesCelsius, R717.Temperature.DegreesCelsius);
             Assert.AreEqual(R717JSON.Tsat.DegreesCelsius, R717.Tsat.DegreesCelsius, 0.00001);
@@ -174,7 +174,7 @@ namespace UnitsTests
             Assert.AreEqual(1.7251500393076753, R717.Prandtl, 0.0001);
             Assert.AreEqual(9.9654295346437216, R717.Pressure.Bars, 0.0001);
             Assert.AreEqual(15.36622602626586, R717.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(0.9176026758197906, R717.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(0.9176026758197906, R717.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0.020532110006759582, R717.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(24.800454983004158, R717.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(24.800454983344366, R717.Tsat.DegreesCelsius, 0.0001);
@@ -205,7 +205,7 @@ namespace UnitsTests
             Assert.AreEqual(R717JSON.Prandtl, R717.Prandtl);
             Assert.AreEqual(R717JSON.Pressure.Bars, R717.Pressure.Bars);
             Assert.AreEqual(R717JSON.Density.KilogramsPerCubicMeter, R717.Density.KilogramsPerCubicMeter);
-            Assert.AreEqual(R717JSON.Entropy.KilocaloriesPerKelvin, R717.Entropy.KilocaloriesPerKelvin);
+            Assert.AreEqual(R717JSON.Entropy.KilocaloriesPerGramKelvin, R717.Entropy.KilocaloriesPerGramKelvin);
             Assert.AreEqual(R717JSON.SurfaceTension.NewtonsPerMeter, R717.SurfaceTension.NewtonsPerMeter);
             Assert.AreEqual(R717JSON.Temperature.DegreesCelsius, R717.Temperature.DegreesCelsius);
             Assert.AreEqual(R717JSON.Tsat.DegreesCelsius, R717.Tsat.DegreesCelsius);
@@ -320,7 +320,7 @@ namespace UnitsTests
             Assert.AreEqual(1.7251500393076753, R717.Prandtl, 0.0001);
             Assert.AreEqual(9.9654295346437216, R717.Pressure.Bars, 0.0001);
             Assert.AreEqual(15.36622602626586, R717.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(0.9176026758197906, R717.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(0.9176026758197906, R717.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0.020532110006759582, R717.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(24.800454983004158, R717.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(24.800454983344366, R717.Tsat.DegreesCelsius, 0.0001);
@@ -348,7 +348,7 @@ namespace UnitsTests
             Assert.AreEqual(R717JSON.Prandtl, R717.Prandtl, 0.0001);
             Assert.AreEqual(R717JSON.Pressure.Bars, R717.Pressure.Bars, 0.0001);
             Assert.AreEqual(R717JSON.Density.KilogramsPerCubicMeter, R717.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(R717JSON.Entropy.KilocaloriesPerKelvin, R717.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(R717JSON.Entropy.KilocaloriesPerGramKelvin, R717.Entropy.KilocaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(R717JSON.SurfaceTension.NewtonsPerMeter, R717.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(R717JSON.Temperature.DegreesCelsius, R717.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(R717JSON.Tsat.DegreesCelsius, R717.Tsat.DegreesCelsius, 0.0001);
@@ -387,7 +387,7 @@ namespace UnitsTests
             Assert.AreEqual(0, R717.Prandtl);
             Assert.AreEqual(Pressure.Zero, R717.Pressure);
             Assert.AreEqual(Density.Zero, R717.Density);
-            Assert.AreEqual(Entropy.Zero, R717.Entropy);
+            Assert.AreEqual(SpecificEntropy.Zero, R717.Entropy);
             Assert.AreEqual(ForcePerLength.Zero, R717.SurfaceTension);
             Assert.AreEqual(Temperature.Zero, R717.Temperature);
             Assert.AreEqual(Temperature.Zero, R717.Tsat);
@@ -433,7 +433,7 @@ namespace UnitsTests
             Assert.AreEqual(0, R717.Prandtl);
             Assert.AreEqual(Pressure.Zero, R717.Pressure);
             Assert.AreEqual(Density.Zero, R717.Density);
-            Assert.AreEqual(Entropy.Zero, R717.Entropy);
+            Assert.AreEqual(SpecificEntropy.Zero, R717.Entropy);
             Assert.AreEqual(ForcePerLength.Zero, R717.SurfaceTension);
             Assert.AreEqual(Temperature.Zero, R717.Temperature);
             Assert.AreEqual(Temperature.Zero, R717.Tsat);
@@ -481,7 +481,7 @@ namespace UnitsTests
             Assert.AreEqual(0, CO2.Prandtl);
             Assert.AreEqual(Pressure.Zero, CO2.Pressure);
             Assert.AreEqual(Density.Zero, CO2.Density);
-            Assert.AreEqual(Entropy.Zero, CO2.Entropy);
+            Assert.AreEqual(SpecificEntropy.Zero, CO2.Entropy);
             Assert.AreEqual(ForcePerLength.Zero, CO2.SurfaceTension);
             Assert.AreEqual(Temperature.Zero, CO2.Temperature);
             Assert.AreEqual(Temperature.Zero, CO2.Tsat);
@@ -528,7 +528,7 @@ namespace UnitsTests
             Assert.AreEqual(0, CO2.Prandtl);
             Assert.AreEqual(Pressure.Zero, CO2.Pressure);
             Assert.AreEqual(Density.Zero, CO2.Density);
-            Assert.AreEqual(Entropy.Zero, CO2.Entropy);
+            Assert.AreEqual(SpecificEntropy.Zero, CO2.Entropy);
             Assert.AreEqual(ForcePerLength.Zero, CO2.SurfaceTension);
             Assert.AreEqual(Temperature.Zero, CO2.Temperature);
             Assert.AreEqual(Temperature.Zero, CO2.Tsat);
@@ -595,7 +595,7 @@ namespace UnitsTests
             Assert.AreEqual(1.7251500393076753, Input1.Prandtl, 0.0001);
             Assert.AreEqual(10.803193843750396, Input1.Pressure.Bars, 0.0001);
             Assert.AreEqual(15.36622602626586, Input1.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(1.133388650011564, Input1.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(1.133388650011564, Input1.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0.020532110006759582, Input1.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(40.529679401767169, Input1.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(27.440898990601966, Input1.Tsat.DegreesCelsius, 0.0001);
@@ -626,7 +626,7 @@ namespace UnitsTests
             Assert.AreEqual(1.0245751602823272, Input2.Prandtl, 0.0001);
             Assert.AreEqual(11.999999999617073, Input2.Pressure.Bars, 0.0001);
             Assert.AreEqual(7.9795686221167559, Input2.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(1.4416543274283831, Input2.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(1.4416543274283831, Input2.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0, Input2.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(63, Input2.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(30.9545445068116, Input2.Tsat.DegreesCelsius, 0.0001);
@@ -688,7 +688,7 @@ namespace UnitsTests
             Assert.AreEqual(1.7251500393076753, Mixer.Prandtl, 0.0001);
             Assert.AreEqual(10.803193843750396, Mixer.Pressure.Bars, 0.0001);
             Assert.AreEqual(15.36622602626586, Mixer.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(1.133388650011564, Mixer.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(1.133388650011564, Mixer.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0.020532110006759582, Mixer.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(40.529679401767169, Mixer.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(27.440898990601966, Mixer.Tsat.DegreesCelsius, 0.0001);
@@ -718,7 +718,7 @@ namespace UnitsTests
             Assert.AreEqual(1.0245751602823272, Input2.Prandtl, 0.0001);
             Assert.AreEqual(11.999999999617073, Input2.Pressure.Bars, 0.0001);
             Assert.AreEqual(7.9795686221167559, Input2.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(1.4416543274283831, Input2.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(1.4416543274283831, Input2.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0, Input2.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(63, Input2.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(30.9545445068116, Input2.Tsat.DegreesCelsius, 0.0001);
@@ -771,7 +771,7 @@ namespace UnitsTests
             Assert.AreEqual(1.6164793487091984, R717.Prandtl, 0.0001);
             Assert.AreEqual(9.9654295346437216, R717.Pressure.Bars, 0.0001);
             Assert.AreEqual(14.17761237163829, R717.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(0.957710977744379, R717.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(0.957710977744379, R717.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0.020532110006681651, R717.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(24.800454983344366, R717.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(24.800454983344366, R717.Tsat.DegreesCelsius, 0.0001);
@@ -820,7 +820,7 @@ namespace UnitsTests
             Assert.AreEqual(0.95670787106984034, R717.Prandtl, 0.0001);
             Assert.AreEqual(9.9654295346437216, R717.Pressure.Bars, 0.0001);
             Assert.AreEqual(2.8241346352757937, R717.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(1.9429350356857431, R717.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(1.9429350356857431, R717.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(R717.LimitTemperatureMax, R717.Temperature);
             Assert.AreEqual(24.800454983344366, R717.Tsat.DegreesCelsius, 0.0001);
@@ -867,7 +867,7 @@ namespace UnitsTests
             Assert.AreEqual(1.8711461600292012, R717.Prandtl, 0.0001);
             Assert.AreEqual(9.96542953464731, R717.Pressure.Bars, 0.0001);
             Assert.AreEqual(16.772377991312993, R717.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(0.87749437389623908, R717.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(0.87749437389623908, R717.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0.020532110006678969, R717.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(24.800454983356076, R717.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(24.800454983356019, R717.Tsat.DegreesCelsius, 0.0001);
@@ -916,7 +916,7 @@ namespace UnitsTests
             Assert.AreEqual(2.970732325948974, R717.Prandtl, 0.0001);
             Assert.AreEqual(9.96542953464731, R717.Pressure.Bars, 0.0001);
             Assert.AreEqual(734.20326325395592, R717.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(-0.00047828927263162855, R717.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(-0.00047828927263162855, R717.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0, R717.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(R717.LimitTemperatureMin, R717.Temperature);
             Assert.AreEqual(24.800454983344366, R717.Tsat.DegreesCelsius, 0.0001);

--- a/UnitsTests/WaterTests.cs
+++ b/UnitsTests/WaterTests.cs
@@ -37,7 +37,7 @@ namespace UnitsTests
             Assert.AreEqual(10000, Water.LimitPressureMax.Bars, 0.0001);
             Assert.AreEqual(0.0061165480089686846, Water.LimitPressureMin.Bars, 0.0001);
             Assert.AreEqual(1.650819966799242, Water.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(1.6710365869337238, Water.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(1.6710365869337238, Water.Entropy.CaloriesPerGramKelvin, 0.0001);
             Assert.AreEqual(0, Water.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(133.522420460943, Water.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(133.52242046094256, Water.Tsat.DegreesCelsius, 0.0001);
@@ -80,7 +80,7 @@ namespace UnitsTests
             Assert.AreEqual(10000, Water.LimitPressureMax.Bars, 0.0001);
             Assert.AreEqual(0.0061165480089686846, Water.LimitPressureMin.Bars, 0.0001);
             Assert.AreEqual(1.2890299515474706, Water.Density.KilogramsPerCubicMeter, 0.0001);
-            Assert.AreEqual(1.7846226274892405, Water.Entropy.KilocaloriesPerKelvin, 0.0001);
+            Assert.AreEqual(1.7846226274892405, Water.Entropy.CaloriesPerGramKelvin, 0.0001);
             //Assert.AreEqual(0.052144997752313106, Water.SurfaceTension.NewtonsPerMeter, 0.0001);
             Assert.AreEqual(237, Water.Temperature.DegreesCelsius, 0.0001);
             Assert.AreEqual(133.522420460943, Water.Tsat.DegreesCelsius, 0.0001);
@@ -124,7 +124,7 @@ namespace UnitsTests
             Assert.AreEqual(0, Water.Prandtl);
             Assert.AreEqual(0, Water.Pressure.Bars);
             Assert.AreEqual(0, Water.Density.KilogramsPerCubicMeter);
-            Assert.AreEqual(0, Water.Entropy.KilocaloriesPerKelvin);
+            Assert.AreEqual(0, Water.Entropy.KilocaloriesPerGramKelvin);
             Assert.AreEqual(0, Water.SurfaceTension.NewtonsPerMeter);
             Assert.AreEqual(0, Water.Temperature.Kelvins);
             Assert.AreEqual(0, Water.Tsat.Kelvins);


### PR DESCRIPTION
Entropy was used everywhere instead of Specific Entropy.
smass has units of specific entropy.
http://www.coolprop.org/coolprop/HighLevelAPI.html
was Joules/Kelvin
is Joules/(kilogram * Kelvin)
I double checked a few numbers in the tests with RefProp to make sure I did it right and it looks good.
