### PR TITLE
Correction of MediaType returning only MixType.Mass

### DIFF
--- a/SharpFluids/SharpFluids files/MediaType.cs
+++ b/SharpFluids/SharpFluids files/MediaType.cs
@@ -40,7 +40,7 @@ namespace SharpFluids
 
             MassFration = massFration;
 
-            mix = Mix;
+            Mix = mix;
 
         }
 


### PR DESCRIPTION
There was a small bug in the MediaType constructor. I have corrected it.