### PR TITLE
linux x86_64 compatibility added, libCoolProp64.so SharpFluids.csproj…

### DIFF
--- a/SharpFluids/SharpFluids.csproj
+++ b/SharpFluids/SharpFluids.csproj
@@ -27,17 +27,23 @@
     <None Include="SharpFluids.targets" PackagePath="build\" Pack="true" />
     <None Include="CoolProp.dll" PackagePath="build\" Pack="true" />
     <None Include="CoolProp64.dll" PackagePath="build\" Pack="true" />
+    <None Include="libCoolProp64.so" PackagePath="build\" Pack="true" />
   
-  <None Update="CoolProp.dll">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <PackagePath>build\</PackagePath>
-            <Pack>true</Pack>
-        </None>
-        <None Update="CoolProp64.dll">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <PackagePath>build\</PackagePath>
-            <Pack>true</Pack>
-        </None>
+	<None Update="CoolProp.dll">
+		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		<PackagePath>build\</PackagePath>
+		<Pack>true</Pack>
+	</None>
+	<None Update="CoolProp64.dll">
+		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		<PackagePath>build\</PackagePath>
+		<Pack>true</Pack>
+	</None>
+	<None Update="libCoolProp64.so">
+		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		<PackagePath>build\</PackagePath>
+		<Pack>true</Pack>
+	</None>
   </ItemGroup>
 
 

--- a/SharpFluids/SharpFluids.nuspec
+++ b/SharpFluids/SharpFluids.nuspec
@@ -24,6 +24,7 @@
 		<file src="..\SharpFluids\SharpFluids.targets" target="build\" />
 		<file src="..\SharpFluids\CoolProp.dll" target="build\" />
 		<file src="..\SharpFluids\CoolProp64.dll" target="build\" />
+		<file src="..\SharpFluids\libCoolProp64.so" target="build\" />
   
   
   </files>

--- a/SharpFluids/SharpFluids.targets
+++ b/SharpFluids/SharpFluids.targets
@@ -1,6 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <NativeLibs Include="$(MSBuildThisFileDirectory)**\*.dll" />
+    <NativeLibs Include="$(MSBuildThisFileDirectory)**\*.so" />
     <None Include="@(NativeLibs)">
       <Link>%(RecursiveDir)%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
I have added a linux library using mono to compile the underlying CoolProps libraries

the name of the file is libCoolProp64.so

The files are added accordingly (rather manually though) into
the csproj, targets and SharpFluids.nuspec 

I've tested this manually using the forked repository as a reference to one of my other test projects. Worked okay.

However i cannot do unit test as dotnet framework isn't exactly available on linux (and i don't want to figure out how to do unit tests in mono, abit time strapped).

Should be okay otherwise. Do build a nuget package and see if it still works!

If you could port the unittests to .NET Core just to test if the libraries work there that would be great. 